### PR TITLE
Fix: Document transaction_id

### DIFF
--- a/models/staging/nas-product-telemetry/_nas_product_telemetry__models.yml
+++ b/models/staging/nas-product-telemetry/_nas_product_telemetry__models.yml
@@ -9,7 +9,7 @@ models:
       transaction patterns, payment methods, and transaction statuses.
     
     columns:
-      - name: transaction
+      - name: transaction_id
         description: Unique identifier for the transaction.
         tests:
           - unique


### PR DESCRIPTION
stg_product__transactions is failing the PK test due to undocumented transaction_id column. This PR will fix the issue by fixing the yml file associated to the said staging model